### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -114,7 +114,7 @@ if (options.port) {
 }
 
 // Starts an HTTP server
-const server = app.listen(portNumber,'localhost', function () {
+const server = app.listen(portNumber, 'localhost', function () {
     const address = server.address();
     console.log('Dolby.io Spatial Audio application is now listening at http://%s:%s', address.address, address.port);
 });


### PR DESCRIPTION
Some devs may not be familiar with the IPv6 [::] output on localhost.  (see https://stackoverflow.com/questions/33853695/node-js-server-address-address-returns )
Added 'localhost' for this example, so the console log will printout the current IP of localhost.  
Makes it easier for a user to cmd  click on the console log output to launch the application and lowers the friction to get started.